### PR TITLE
remove StaticArrays and make a few promotion fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6-
-StaticArrays 0.4
+julia 0.6-pre
 MacroTools 0.3.6

--- a/src/TypedPolynomials.jl
+++ b/src/TypedPolynomials.jl
@@ -1,6 +1,5 @@
 module TypedPolynomials
 
-using StaticArrays: SVector
 using MacroTools
 import Base: *, +, -, /, ^, ==,
     promote_rule, convert, show, isless, size, getindex,

--- a/src/abstract/operators.jl
+++ b/src/abstract/operators.jl
@@ -110,4 +110,5 @@ iszero(p::AbstractPolynomial) = all(iszero, terms(p))
 Convert a tuple of variables into a static vector to allow array-like usage.
 The element type of the vector will be Monomial{vars, length(vars)}.
 """
-vec(vars::Tuple{Vararg{<:AbstractVariable}}) = SVector(vars)
+vec(vars::Tuple{Vararg{<:AbstractVariable}}) = [vars...]
+# vec(vars::Tuple{Vararg{<:AbstractVariable}}) = SVector(vars)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -38,7 +38,7 @@ function convert(::Type{Monomial{V1, N1}}, m::Monomial) where {V1, N1}
     Monomial{V1, N1}(exps)
 end
 
-convert(::Type{Term{T1, M1}}, t::Term) where {T1, M1} = Term(convert(T1, t.coefficient), convert(M1, t.monomial))
+convert(::Type{Term{T1, M1}}, t::Term) where {T1, M1} = Term{T1, M1}(convert(T1, t.coefficient), convert(M1, t.monomial))
 convert(::Type{AbstractTerm}, coeff, mono::Monomial) = Term(coeff, mono)
 convert(::Type{AbstractPolynomial}, t::TermLike) = Polynomial(t)
 convert(::Type{AbstractPolynomial}, v::AbstractVector{<:Term}) = Polynomial(v)

--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -60,34 +60,34 @@ function promote_rule(::Type{Term{T, M2}}, ::Type{M1}) where {M1 <: Monomial, T,
 end
 promote_rule(M::Type{<:Monomial}, T::Type{<:Term}) = promote_rule(T, M)
 
-function _promote_term(::Type{Term{T1, M1}}, ::Type{Term{T2, M2}}) where {T1, M1, T2, M2}
-    Term{promote_type(T1, T2), promote_type(M1, M2)}
-end
+# function _promote_term(::Type{Term{T1, M1}}, ::Type{Term{T2, M2}}) where {T1, M1, T2, M2}
+#     Term{promote_type(T1, T2), promote_type(M1, M2)}
+# end
 
-promote_rule(T1::Type{<:Term}, T2::Type{<:Term}) = _promote_term(T1, T2)
+promote_rule(::Type{Term{T1, M1}}, ::Type{Term{T2, M2}}) where {T1, M1 <: Monomial, T2, M2 <: Monomial} = Term{promote_type(T1, T2), promote_type(M1, M2)}
 
 function promote_rule(::Type{<:Polynomial{T2}}, ::Type{T1}) where {T1 <: TermLike, T2 <: Term}
     T = promote_type(T1, T2)
     Polynomial{T, Vector{T}}
 end
-promote_rule(T::Type{<:Term}, P::Type{<:Polynomial}) = promote_rule(P, T)
+promote_rule(T::Type{Term{T1, M1}}, P::Type{<:Polynomial}) where {T1, M1 <: Monomial} = promote_rule(P, T)
 promote_rule(T::Type{<:Monomial}, P::Type{<:Polynomial}) = promote_rule(P, T)
 promote_rule(T::Type{<:Variable}, P::Type{<:Polynomial}) = promote_rule(P, T)
 
-function promote_rule(::Type{Polynomial{T2, SVector{N, T2}}}, ::Type{T1}) where {T1 <: TermLike, T2 <: Term, N}
-    T = promote_type(T1, T2)
-    Polynomial{T, SVector{N, T}}
-end
+# function promote_rule(::Type{Polynomial{T2, SVector{N, T2}}}, ::Type{T1}) where {T1 <: TermLike, T2 <: Term, N}
+#     T = promote_type(T1, T2)
+#     Polynomial{T, SVector{N, T}}
+# end
 
 function promote_rule(::Type{<:Polynomial{T1}}, ::Type{<:Polynomial{T2}}) where {T1 <: TermLike, T2 <: TermLike}
     T = promote_type(T1, T2)
     Polynomial{T, Vector{T}}
 end
 
-function promote_rule(::Type{Polynomial{T1, SVector{1, T1}}}, ::Type{Polynomial{T2, SVector{1, T2}}}) where {T1, T2}
-    T = promote_type(T1, T2)
-    Polynomial{T, SVector{1, T}}
-end
+# function promote_rule(::Type{Polynomial{T1, SVector{1, T1}}}, ::Type{Polynomial{T2, SVector{1, T2}}}) where {T1, T2}
+#     T = promote_type(T1, T2)
+#     Polynomial{T, SVector{1, T}}
+# end
 
 function promote_rule(::Type{V}, ::Type{S}) where {S, V <: Variable}
     Term{S, Monomial{(V(),), 1}}
@@ -97,11 +97,11 @@ function promote_rule(::Type{M}, ::Type{S}) where {S, M <: Monomial}
     Term{S, M}
 end
 
-function _promote_any_term(::Type{S}, ::Type{Term{T, M}}) where {S, T, M <: Monomial}
-    Term{promote_type(S, T), M}
-end
+# function _promote_any_term(::Type{S}, ::Type{Term{T, M}}) where {S, T, M <: Monomial}
+#     Term{promote_type(S, T), M}
+# end
 
-promote_rule(t::Type{<:Term}, s) = _promote_any_term(s, t)
+promote_rule(t::Type{Term{T, M}}, ::Type{S}) where {T, M <: Monomial, S} = Term{promote_type(S, T), M}
 
 function promote_rule(::Type{<:Polynomial{T}}, ::Type{S}) where {S, T <: TermLike}
     R = promote_type(S, T)

--- a/src/types.jl
+++ b/src/types.jl
@@ -43,7 +43,8 @@ immutable Polynomial{T <: Term, V <: AbstractVector{T}} <: AbstractPolynomial
 end
 Polynomial(terms::AbstractVector{T}) where {T <: Term} = Polynomial{T, typeof(terms)}(terms)
 Polynomial(t::AbstractVector) = Polynomial(Term.(t))
-Polynomial(term::Term) = Polynomial(SVector(term))
+# Polynomial(term::Term) = Polynomial(SVector(term))
+Polynomial(term::Term) = Polynomial([term])
 Polynomial(x) = Polynomial(Term(x))
 termtype(::Type{<:Polynomial{T}}) where {T} = T
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -2,7 +2,7 @@ module M
 
 using Base.Test
 using TypedPolynomials: @polyvar, Variable
-using StaticArrays: SVector
+# using StaticArrays: SVector
 
 @testset "macros" begin
     @polyvar x
@@ -15,7 +15,7 @@ using StaticArrays: SVector
 
     @polyvar a[1:3]
     @test typeof(a) == Tuple{Variable{:a1}, Variable{:a2}, Variable{:a3}}
-    @test vec(a) == SVector(a)
+    # @test vec(a) == SVector(a)
 
     @polyvar b c[1:2]
     @test typeof(b) == Variable{:b}

--- a/test/polynomials.jl
+++ b/test/polynomials.jl
@@ -182,8 +182,8 @@ end
     @test extdeg(p) == (1, 3)
     @test nvars(p) == 2
 
-    @test (@wrappedallocs x^2 + y + x * x + 3 * x * y + x * y) <= 736
-    @test (@wrappedallocs x^2 + 1) <= 128
+    @test (@wrappedallocs x^2 + y + x * x + 3 * x * y + x * y) <= 1376
+    @test (@wrappedallocs x^2 + 1) <= 384
 
     @test (1 + x) * (x + 3) == 3 + 4x + x^2
     @test (2.0 + x) * (y + 1) == 2 + 2y + x + x * y

--- a/test/promotion.jl
+++ b/test/promotion.jl
@@ -12,7 +12,7 @@
     @test typeof(@inferred promote(y, x)) == NTuple{2, Monomial{(x, y), 2}}
     @test typeof(@inferred promote(x, y^2)) == NTuple{2, Monomial{(x, y), 2}}
     @test typeof(@inferred promote(x, 2y)) == NTuple{2, Term{Int, Monomial{(x, y), 2}}}
-    @test typeof(@inferred promote(x, Polynomial(2y))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, SVector{1, Term{Int, Monomial{(x, y), 2}}}}}
+    @test typeof(@inferred promote(x, Polynomial(2y))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
     @test typeof(@inferred promote(x, Polynomial([2y]))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
 
     @test typeof(@inferred promote(x^2, 1)) == NTuple{2, Term{Int, Monomial{(x,), 1}}}
@@ -20,21 +20,21 @@
     @test typeof(@inferred promote(y, x^2)) == NTuple{2, Monomial{(x, y), 2}}
     @test typeof(@inferred promote(x^2, y^2)) == NTuple{2, Monomial{(x, y), 2}}
     @test typeof(@inferred promote(x^2, 2y)) == NTuple{2, Term{Int, Monomial{(x, y), 2}}}
-    @test typeof(@inferred promote(x^2, Polynomial(2y))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, SVector{1, Term{Int, Monomial{(x, y), 2}}}}}
+    @test typeof(@inferred promote(x^2, Polynomial(2y))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
     @test typeof(@inferred promote(x^2, Polynomial([2y]))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
 
     @test typeof(@inferred promote(2x, 1)) == NTuple{2, Term{Int, Monomial{(x,), 1}}}
     @test typeof(@inferred promote(2x, y)) == NTuple{2, Term{Int, Monomial{(x, y), 2}}}
     @test typeof(@inferred promote(2x, y^2)) == NTuple{2, Term{Int, Monomial{(x, y), 2}}}
     @test typeof(@inferred promote(2x, 2y)) == NTuple{2, Term{Int, Monomial{(x, y), 2}}}
-    @test typeof(@inferred promote(2x, Polynomial(2y))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, SVector{1, Term{Int, Monomial{(x, y), 2}}}}}
+    @test typeof(@inferred promote(2x, Polynomial(2y))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
     @test typeof(@inferred promote(2x, Polynomial([2y]))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
 
     @test typeof(@inferred promote(Polynomial(2x), 1)) == NTuple{2, Polynomial{Term{Int, Monomial{(x,), 1}}, Vector{Term{Int, Monomial{(x,), 1}}}}}
-    @test typeof(@inferred promote(Polynomial(2x), y)) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, SVector{1, Term{Int, Monomial{(x, y), 2}}}}}
-    @test typeof(@inferred promote(Polynomial(2x), y^2)) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, SVector{1, Term{Int, Monomial{(x, y), 2}}}}}
-    @test typeof(@inferred promote(Polynomial(2x), 2y)) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, SVector{1, Term{Int, Monomial{(x, y), 2}}}}}
-    @test typeof(@inferred promote(Polynomial(2x), Polynomial(2y))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, SVector{1, Term{Int, Monomial{(x, y), 2}}}}}
+    @test typeof(@inferred promote(Polynomial(2x), y)) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
+    @test typeof(@inferred promote(Polynomial(2x), y^2)) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
+    @test typeof(@inferred promote(Polynomial(2x), 2y)) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
+    @test typeof(@inferred promote(Polynomial(2x), Polynomial(2y))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
     @test typeof(@inferred promote(Polynomial(2x), Polynomial([2y]))) == NTuple{2, Polynomial{Term{Int, Monomial{(x, y), 2}}, Vector{Term{Int, Monomial{(x, y), 2}}}}}
 
     @test typeof(@inferred(promote(Monomial{tuple(), 0}(), x))) == NTuple{2, Monomial{(x,), 1}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using TypedPolynomials
 using Base.Test
-using StaticArrays: SVector
 
 """
     @wrappedallocs(expr)


### PR DESCRIPTION
fixes #27 

I also removed the StaticArrays dependency for now (it was only being used for automatic promotion from Term to Polynomial with a single term). This will cause some mild performance loss, but it makes the code a bit simpler and more reliable. We can bring StaticArrays back very easily once the last remaining v0.6 issues are worked out. 